### PR TITLE
Use the latest release by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: MOZGIII/install-ldid-action@<action-version>
         with:
-          tag: v2.1.5-procursus2
+          tag: v2.1.5-procursus2 # optional, defaults to the latest release
       - run: ldid
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,8 @@ inputs:
     default: ProcursusTeam/ldid
   tag:
     description: Github Release Tag to use
-    required: true
+    required: false
+    default: latest
 runs:
   using: "composite"
   steps:

--- a/install.sh
+++ b/install.sh
@@ -21,8 +21,15 @@ esac
 
 FNAME="ldid_${OS_NAME}_${ARCH_NAME}"
 
+if [ -z "$TAG" || "$TAG" = "latest"]
+then
+  URL="https://github.com/${REPO}/releases/latest/download/${FNAME}"
+else
+  URL="https://github.com/${REPO}/releases/download/${TAG}/${FNAME}"
+fi
+
 curl -sSL \
   -o "$DIR/$FNAME" \
-  "https://github.com/${REPO}/releases/download/${TAG}/${FNAME}"
+  "$URL"
 chmod +x "$DIR/$FNAME"
 cp "$DIR/$FNAME" /usr/local/bin/ldid


### PR DESCRIPTION
The `tag` input is made optional.

Downloads the latest release if `tag` equals to `latest` or empty.